### PR TITLE
Member pointer is null when owner expired

### DIFF
--- a/include/cycle_ptr/detail/vertex.h
+++ b/include/cycle_ptr/detail/vertex.h
@@ -33,7 +33,7 @@ class vertex
   ~vertex() noexcept;
 
   cycle_ptr_export_
-  auto reset() -> void;
+  auto reset() noexcept -> void;
 
   /**
    * \brief Assign a new \p new_dst.
@@ -51,21 +51,12 @@ class vertex
   auto reset(
       intrusive_ptr<base_control> new_dst,
       bool has_reference,
-      bool no_red_promotion)
+      bool no_red_promotion) noexcept
   -> void;
 
   ///\brief Test if origin is expired.
   cycle_ptr_export_
   auto owner_is_expired() const noexcept -> bool;
-
-  ///\brief Throw exception if owner is expired.
-  ///\details
-  ///It is not allowed to read member pointers from an expired object.
-  ///\todo Create dedicated exception for this case.
-  auto throw_if_owner_expired() const
-  -> void {
-    if (owner_is_expired()) throw std::bad_weak_ptr();
-  }
 
  public:
   ///\brief Read the target control block.


### PR DESCRIPTION
Old behaviour was that, if `MyClass` was expired, all its member-pointers on dereference/assignment would throw `std::bad_weak_ptr`.

New behaviour is that all those pointers are `nullptr`.

A lot less code was changed that should be the case: it turns out a lot of the code (such as `swap`, or `operator==`) accidentally assumed dereference to never fail already, so it already carried `noexcept`-specifiers.

I chose to use an `if`-clause in the `get()` function to implement the new behaviour. I don't think I require it for thread-safety (expired objects should only have a single thread acting on them anyway). It's more that changing vertex to hold a pointer, and doing the appropriate casts, would be a large change. (Which I probably ought to do at some point, to implement `std::atomic` pointers.)